### PR TITLE
feat: update object similarity calculation

### DIFF
--- a/src/main/java/com/deblock/jsondiff/diff/JsonObjectDiff.java
+++ b/src/main/java/com/deblock/jsondiff/diff/JsonObjectDiff.java
@@ -8,8 +8,8 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class JsonObjectDiff implements JsonDiff {
-    private static final int STRUCTURE_MAX_RATIO = 50;
-    private static final int VALUE_MAX_RATIO = 50;
+    private static final int STRUCTURE_MAX_RATIO = 60;
+    private static final int VALUE_MAX_RATIO = 40;
 
     private final Map<String, JsonDiff> propertiesDiff = new HashMap<>();
     private final Map<String, JsonNode> notFoundProperties = new HashMap<>();
@@ -46,7 +46,7 @@ public class JsonObjectDiff implements JsonDiff {
         if (propertiesDiff.isEmpty()) {
             equalityRatio = 0;
         } else {
-            equalityRatio = propertiesSimilarityRate * VALUE_MAX_RATIO / (propertiesDiff.size() * 100);
+            equalityRatio = propertiesSimilarityRate * VALUE_MAX_RATIO / (totalPropertiesCount * 100);
         }
         return structureRatio + equalityRatio;
     }

--- a/src/test/java/com/deblock/jsondiff/matcher/JsonDiffAsserter.java
+++ b/src/test/java/com/deblock/jsondiff/matcher/JsonDiffAsserter.java
@@ -17,6 +17,7 @@ public class JsonDiffAsserter implements JsonDiffViewer {
     private final List<MatchingPropertyAsserter> matchingPropertyAsserters = new ArrayList<>();
     private final List<PrimaryNonMatchingAsserter> primaryNonMatchingAsserters = new ArrayList<>();
     private final List<PrimaryMatchingAsserter> primaryMatchingAsserters = new ArrayList<>();
+    private Double expectedSimilarityRate = null;
 
     @Override
     public void matchingProperty(Path path, JsonDiff diff) {
@@ -79,6 +80,14 @@ public class JsonDiffAsserter implements JsonDiffViewer {
     }
 
     public void validate(JsonDiff jsonDiff) {
+        if (this.expectedSimilarityRate != null && this.expectedSimilarityRate != jsonDiff.similarityRate()) {
+            throw new AssertionError(
+                    String.format(
+                            "The similarity rate should be equals to \"%s\" but actual value is \"%s\"",
+                            this.expectedSimilarityRate, jsonDiff.similarityRate()
+                    )
+            );
+        }
         jsonDiff.display(this);
 
         final var allErrors = Stream.of(missingPropertyAsserters, nonMatchingPropertyAsserters, matchingPropertyAsserters, primaryNonMatchingAsserters, extraPropertyAsserters)
@@ -119,6 +128,11 @@ public class JsonDiffAsserter implements JsonDiffViewer {
 
     public JsonDiffAsserter assertExtraProperty(Path path) {
         this.extraPropertyAsserters.add(new ExtraPropertyAsserter(path));
+        return this;
+    }
+
+    public JsonDiffAsserter assertSimilarityRate(double structural, double value) {
+        this.expectedSimilarityRate = structural + value;
         return this;
     }
 


### PR DESCRIPTION
- with this change structure similarity is 60% of the result and value similarity is 40% of the result
- the value similarity is now `number of value match / number of expected property` instead of `number of value match / number of matched keys`. This avoids to have a high ratio if only one key match the expected object.

before: 
 - `{ "a": 1, "d": 5 }` and `{ "a": 1, "d": 2 }`: have a value similarity  equals to 0.5
 - `{ "a": 1, "d": 5 }` and `{ "a": 1 }`: have a value similarity  equals to 1

now:
 - `{ "a": 1, "d": 5 }` and `{ "a": 1, "d": 2 }`: have a value similarity  equals to 0.5
 - `{ "a": 1, "d": 5 }` and `{ "a": 1 }`: have a value similarity  equals to 0.5

close #8