### PR TITLE
Optimisation of n square array node comparison in LenientJsonArrayPartialMatcher

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/src/main/java/com/deblock/jsondiff/matcher/LenientJsonArrayPartialMatcher.java
+++ b/src/main/java/com/deblock/jsondiff/matcher/LenientJsonArrayPartialMatcher.java
@@ -2,56 +2,115 @@ package com.deblock.jsondiff.matcher;
 
 import com.deblock.jsondiff.diff.JsonArrayDiff;
 import com.deblock.jsondiff.diff.JsonDiff;
+import com.deblock.jsondiff.model.IndexedJsonNode;
+import com.deblock.jsondiff.model.MismatchPair;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 
 import java.util.*;
 import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 
 public class LenientJsonArrayPartialMatcher implements PartialJsonMatcher<ArrayNode> {
     @Override
-    public JsonDiff jsonDiff(Path path, ArrayNode expectedValues, ArrayNode receivedValues, JsonMatcher jsonMatcher) {
+    public JsonDiff jsonDiff(Path path, ArrayNode expectedArrayNode, ArrayNode recievedArrayNode, JsonMatcher jsonMatcher) {
         final var diff = new JsonArrayDiff(path);
-
-        var i = 0;
-        final var diffMap = new HashMap<Integer, Map<Integer, JsonDiff>>();
-        for (final var expectedValue: expectedValues) {
-            final var map = new HashMap<Integer, JsonDiff>();
-            for (var x = 0; x < receivedValues.size(); ++x) {
-                map.put(x, jsonMatcher.diff(path.add(Path.PathItem.of(i)), expectedValue, receivedValues.get(x)));
+        var mismatches = processMatchingArrayNodesAndReportMismatches(expectedArrayNode, recievedArrayNode, diff, path, jsonMatcher);
+        if (!mismatches.getExpectedMissing().isEmpty() || !mismatches.getActualMissing().isEmpty()) {
+            final var diffMap = new HashMap<Integer, Map<Integer, JsonDiff>>();
+            for (int i = 0; i < mismatches.getExpectedMissing().size(); i++) {
+                final var map = new HashMap<Integer, JsonDiff>();
+                var expectedMissingIndex=mismatches.getExpectedMissing().get(i).getIndex();
+                var expectedMissing=mismatches.getExpectedMissing().get(i);
+                for (var x = 0; x < mismatches.getActualMissing().size(); ++x) {
+                    var actualMissingIndex=mismatches.getActualMissing().get(x).getIndex();
+                    var actualMissing=mismatches.getActualMissing().get(x);
+                    map.put(actualMissingIndex, jsonMatcher.diff(path.add(Path.PathItem.of(expectedMissingIndex)),
+                            expectedMissing.getJsonNode(),actualMissing.getJsonNode()));
+                }
+                diffMap.put(expectedMissingIndex, map);
             }
-            diffMap.put(i, map);
-            ++i;
-        }
 
-        final var entrySortedByBestMatch =
-                diffMap.entrySet().stream()
-                        .sorted(Comparator.comparingDouble(this::maxSimilarityRate).reversed())
-                        .collect(Collectors.toList());
-        final var alreadyMatchedIndex = new HashSet<Integer>();
+            final var entrySortedByBestMatch =
+                    diffMap.entrySet().stream()
+                            .sorted(Comparator.comparingDouble(this::maxSimilarityRate).reversed())
+                            .toList();
+            final var alreadyMatchedIndex = new HashSet<Integer>();
 
-        for (final var entry: entrySortedByBestMatch) {
-            final var matchedItem = entry.getValue().entrySet().stream()
-                    .filter(e -> !alreadyMatchedIndex.contains(e.getKey()))
-                    .max(Comparator.comparingDouble(e -> e.getValue().similarityRate()));
+            for (final var entry : entrySortedByBestMatch) {
+                final var matchedItem = entry.getValue().entrySet().stream()
+                        .filter(e -> !alreadyMatchedIndex.contains(e.getKey()))
+                        .max(Comparator.comparingDouble(e -> e.getValue().similarityRate()));
 
-            if (matchedItem.isEmpty()) {
-                diff.addNoMatch(entry.getKey(), expectedValues.get(entry.getKey()));
-            } else {
-                diff.addDiff(entry.getKey(), matchedItem.get().getValue());
-                alreadyMatchedIndex.add(matchedItem.get().getKey());
+                if (matchedItem.isEmpty()) {
+                    diff.addNoMatch(entry.getKey(), expectedArrayNode.get(entry.getKey()));
+                } else {
+                    diff.addDiff(entry.getKey(), matchedItem.get().getValue());
+                    alreadyMatchedIndex.add(matchedItem.get().getKey());
+                }
+            }
+
+            if (alreadyMatchedIndex.size() < recievedArrayNode.size()) {
+                final var receivedIndex = mismatches.getActualMissing().stream().map(IndexedJsonNode::getIndex).collect(Collectors.toList());
+                receivedIndex.removeAll(alreadyMatchedIndex);
+                receivedIndex.forEach(index -> diff.addExtraItem(index, recievedArrayNode.get(index)));
             }
         }
 
-        if (alreadyMatchedIndex.size() < receivedValues.size()) {
-            final var receivedIndex = IntStream.range(0, receivedValues.size()).boxed().collect(Collectors.toList());
-            receivedIndex.removeAll(alreadyMatchedIndex);
-            receivedIndex.forEach(index -> diff.addExtraItem(index, receivedValues.get(index)));
-        }
         return diff;
     }
 
     private double maxSimilarityRate(Map.Entry<Integer, Map<Integer, JsonDiff>> entry) {
         return entry.getValue().values().stream().mapToDouble(JsonDiff::similarityRate).max().orElse(0);
+    }
+
+    private MismatchPair<List<IndexedJsonNode>, List<IndexedJsonNode>> processMatchingArrayNodesAndReportMismatches(ArrayNode expectedArrayNode, ArrayNode actualArrayNode, JsonArrayDiff diff, Path path, JsonMatcher jsonMatcher) {
+        List<IndexedJsonNode> expectedMissing = new ArrayList<>();
+        List<IndexedJsonNode> actualMissing = new ArrayList<>();
+
+        if (actualArrayNode.equals(expectedArrayNode)) {
+            for (int i = 0; i < expectedArrayNode.size(); i++) {
+                diff.addDiff(i, jsonMatcher.diff(path.add(Path.PathItem.of(i)), expectedArrayNode.get(i), expectedArrayNode.get(i)));
+            }
+            return new MismatchPair<>(expectedMissing, actualMissing);
+        }
+        Map<JsonNode, Integer> expectedNodeCounter = getElementsWithCount(expectedArrayNode.elements());
+        Map<JsonNode, Integer> actualNodeCounter = getElementsWithCount(actualArrayNode.elements());
+
+        for (int i = 0; i < expectedArrayNode.size(); i++) {
+            var expectedElement = expectedArrayNode.get(i);
+            if (!actualNodeCounter.containsKey(expectedElement)) {
+                expectedMissing.add(new IndexedJsonNode(i, expectedArrayNode.get(i)));
+            } else {
+                actualNodeCounter.put(expectedElement, actualNodeCounter.get(expectedElement) - 1);
+                if (actualNodeCounter.get(expectedElement) == 0) {
+                    actualNodeCounter.remove(expectedElement);
+                }
+                diff.addDiff(i, jsonMatcher.diff(path.add(Path.PathItem.of(i)), expectedElement, expectedElement));
+            }
+        }
+        for (int i = 0; i < actualArrayNode.size(); i++) {
+            var actualElement = actualArrayNode.get(i);
+            if (!expectedNodeCounter.containsKey(actualElement)) {
+                actualMissing.add(new IndexedJsonNode(i, actualArrayNode.get(i)));
+            } else {
+                expectedNodeCounter.put(actualElement, expectedNodeCounter.get(actualElement) - 1);
+                if (expectedNodeCounter.get(actualElement) == 0) {
+                    expectedNodeCounter.remove(actualElement);
+                }
+            }
+        }
+        return new MismatchPair<>(expectedMissing, actualMissing);
+    }
+
+    private <T> Map<T, Integer> getElementsWithCount(Iterator<T> elements) {
+        Map<T, Integer> nodeCounter = new HashMap<>();
+        elements.forEachRemaining(
+                element -> {
+                    if (nodeCounter.containsKey(element)) {
+                        nodeCounter.put(element, nodeCounter.getOrDefault(element, 0) + 1);
+                    }
+                }
+        );
+        return nodeCounter;
     }
 }

--- a/src/main/java/com/deblock/jsondiff/model/IndexedJsonNode.java
+++ b/src/main/java/com/deblock/jsondiff/model/IndexedJsonNode.java
@@ -1,0 +1,29 @@
+package com.deblock.jsondiff.model;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+public class IndexedJsonNode {
+    int index;
+    JsonNode jsonNode;
+
+    public IndexedJsonNode(int index, JsonNode jsonNode) {
+        this.index = index;
+        this.jsonNode = jsonNode;
+    }
+
+    public int getIndex() {
+        return index;
+    }
+
+    public void setIndex(int index) {
+        this.index = index;
+    }
+
+    public JsonNode getJsonNode() {
+        return jsonNode;
+    }
+
+    public void setJsonNode(JsonNode jsonNode) {
+        this.jsonNode = jsonNode;
+    }
+}

--- a/src/main/java/com/deblock/jsondiff/model/MismatchPair.java
+++ b/src/main/java/com/deblock/jsondiff/model/MismatchPair.java
@@ -1,0 +1,47 @@
+package com.deblock.jsondiff.model;
+
+public class MismatchPair<K, V> {
+    private K expected;
+    private V actual;
+
+    public MismatchPair(K expected, V actual) {
+        this.expected = expected;
+        this.actual = actual;
+    }
+
+    public K getExpectedMissing() {
+        return expected;
+    }
+
+    public void setExpected(K expected) {
+        this.expected = expected;
+    }
+
+    public V getActualMissing() {
+        return actual;
+    }
+
+    public void setActual(V actual) {
+        this.actual = actual;
+    }
+
+    @Override
+    public String toString() {
+        return "(" + expected + ", " + actual + ")";
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) return true;
+        if (obj == null || getClass() != obj.getClass()) return false;
+        MismatchPair<?, ?> mismatchPair = (MismatchPair<?, ?>) obj;
+        return expected.equals(mismatchPair.expected) && actual.equals(mismatchPair.actual);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = expected.hashCode();
+        result = 31 * result + actual.hashCode();
+        return result;
+    }
+}


### PR DESCRIPTION
LenientJsonArrayPartialMatcher performs a comparison of each element in the expected array node with each element in the actual array node, resulting in n^2 complexity for calculating the similarity score before identifying the best matching pairs for comparison. [Here is the code link](https://github.com/deblockt/json-diff/blob/416e8f8a0f75d74e1ca417577445d14ea1b515fd/src/main/java/com/deblock/jsondiff/matcher/LenientJsonArrayPartialMatcher.java#L18).

I identified an opportunity for optimization in this process. By filtering out identical elements [code link](https://github.com/aymar99/json-diff/blob/d5067d49d5d2ea16298feeda338b6f73911414d8/src/main/java/com/deblock/jsondiff/matcher/LenientJsonArrayPartialMatcher.java#L17) from both the expected and actual arrays before applying the n^2 similarity score calculation, we can significantly reduce the complexity. In scenarios where there are only a few mismatches between the expected and actual arrays, this optimization ensures that the n^2 complexity is only applied to those differing elements. The worst-case scenario of n^2 for all elements in the array occurs only if none of the elements match.

For smaller JSONs, the implementation may not exhibit a noticeable difference. However, during testing with larger JSONs containing hundreds of array elements, a significant performance improvement becomes apparent. I have tested this enhancement and created a pull request. I would appreciate it if you could review the pull request and share your thoughts!