### PR TITLE
feat: optimize json array partial matcher for big json file

### DIFF
--- a/src/main/java/com/deblock/jsondiff/matcher/LenientJsonArrayPartialMatcher.java
+++ b/src/main/java/com/deblock/jsondiff/matcher/LenientJsonArrayPartialMatcher.java
@@ -2,56 +2,145 @@ package com.deblock.jsondiff.matcher;
 
 import com.deblock.jsondiff.diff.JsonArrayDiff;
 import com.deblock.jsondiff.diff.JsonDiff;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 
 public class LenientJsonArrayPartialMatcher implements PartialJsonMatcher<ArrayNode> {
     @Override
-    public JsonDiff jsonDiff(Path path, ArrayNode expectedValues, ArrayNode receivedValues, JsonMatcher jsonMatcher) {
+    public JsonDiff jsonDiff(Path path, ArrayNode expectedArrayNode, ArrayNode recievedArrayNode, JsonMatcher jsonMatcher) {
         final var diff = new JsonArrayDiff(path);
-
-        var i = 0;
-        final var diffMap = new HashMap<Integer, Map<Integer, JsonDiff>>();
-        for (final var expectedValue: expectedValues) {
-            final var map = new HashMap<Integer, JsonDiff>();
-            for (var x = 0; x < receivedValues.size(); ++x) {
-                map.put(x, jsonMatcher.diff(path.add(Path.PathItem.of(i)), expectedValue, receivedValues.get(x)));
+        var mismatches = processMatchingArrayNodesAndReportMismatches(expectedArrayNode, recievedArrayNode, diff, path, jsonMatcher);
+        if (!mismatches.expectedMissing.isEmpty() || !mismatches.actualMissing.isEmpty()) {
+            final var diffMap = new HashMap<Integer, Map<Integer, JsonDiff>>();
+            for (var expectedMissing: mismatches.expectedMissing) {
+                final var map = new HashMap<Integer, JsonDiff>();
+                for (var actualMissing: mismatches.actualMissing) {
+                    map.put(
+                        actualMissing.index,
+                        jsonMatcher.diff(
+                            path.add(Path.PathItem.of(expectedMissing.index)), expectedMissing.jsonNode, actualMissing.jsonNode
+                        )
+                    );
+                }
+                diffMap.put(expectedMissing.index, map);
             }
-            diffMap.put(i, map);
-            ++i;
-        }
 
-        final var entrySortedByBestMatch =
-                diffMap.entrySet().stream()
-                        .sorted(Comparator.comparingDouble(this::maxSimilarityRate).reversed())
-                        .collect(Collectors.toList());
-        final var alreadyMatchedIndex = new HashSet<Integer>();
+            final var entrySortedByBestMatch =
+                    diffMap.entrySet().stream()
+                            .sorted(Comparator.comparingDouble(this::maxSimilarityRate).reversed())
+                            .toList();
+            final var alreadyMatchedIndex = new HashSet<Integer>();
 
-        for (final var entry: entrySortedByBestMatch) {
-            final var matchedItem = entry.getValue().entrySet().stream()
-                    .filter(e -> !alreadyMatchedIndex.contains(e.getKey()))
-                    .max(Comparator.comparingDouble(e -> e.getValue().similarityRate()));
+            for (final var entry : entrySortedByBestMatch) {
+                final var matchedItem = entry.getValue().entrySet().stream()
+                        .filter(e -> !alreadyMatchedIndex.contains(e.getKey()))
+                        .max(Comparator.comparingDouble(e -> e.getValue().similarityRate()));
 
-            if (matchedItem.isEmpty()) {
-                diff.addNoMatch(entry.getKey(), expectedValues.get(entry.getKey()));
-            } else {
-                diff.addDiff(entry.getKey(), matchedItem.get().getValue());
-                alreadyMatchedIndex.add(matchedItem.get().getKey());
+                if (matchedItem.isEmpty()) {
+                    diff.addNoMatch(entry.getKey(), expectedArrayNode.get(entry.getKey()));
+                } else {
+                    diff.addDiff(entry.getKey(), matchedItem.get().getValue());
+                    alreadyMatchedIndex.add(matchedItem.get().getKey());
+                }
+            }
+
+            if (alreadyMatchedIndex.size() < recievedArrayNode.size()) {
+                final var receivedIndex = mismatches.actualMissing.stream().map(it -> it.index).collect(Collectors.toList());
+                receivedIndex.removeAll(alreadyMatchedIndex);
+                receivedIndex.forEach(index -> diff.addExtraItem(index, recievedArrayNode.get(index)));
             }
         }
 
-        if (alreadyMatchedIndex.size() < receivedValues.size()) {
-            final var receivedIndex = IntStream.range(0, receivedValues.size()).boxed().collect(Collectors.toList());
-            receivedIndex.removeAll(alreadyMatchedIndex);
-            receivedIndex.forEach(index -> diff.addExtraItem(index, receivedValues.get(index)));
-        }
         return diff;
     }
 
     private double maxSimilarityRate(Map.Entry<Integer, Map<Integer, JsonDiff>> entry) {
         return entry.getValue().values().stream().mapToDouble(JsonDiff::similarityRate).max().orElse(0);
+    }
+
+    private MismatchPair<List<IndexedJsonNode>, List<IndexedJsonNode>> processMatchingArrayNodesAndReportMismatches(ArrayNode expectedArrayNode, ArrayNode actualArrayNode, JsonArrayDiff diff, Path path, JsonMatcher jsonMatcher) {
+        if (actualArrayNode.equals(expectedArrayNode)) {
+            for (int i = 0; i < expectedArrayNode.size(); i++) {
+                diff.addDiff(i, jsonMatcher.diff(path.add(Path.PathItem.of(i)), expectedArrayNode.get(i), expectedArrayNode.get(i)));
+            }
+            return new MismatchPair<>(List.of(), List.of());
+        }
+        List<IndexedJsonNode> expectedMissing = new ArrayList<>();
+        List<IndexedJsonNode> actualMissing = new ArrayList<>();
+        NodeCounter expectedNodeCounter = getElementsWithCount(expectedArrayNode.elements());
+        NodeCounter actualNodeCounter = getElementsWithCount(actualArrayNode.elements());
+
+        for (int i = 0; i < expectedArrayNode.size(); i++) {
+            var expectedElement = expectedArrayNode.get(i);
+            if (actualNodeCounter.containsNode(expectedElement)) {
+                actualNodeCounter.removeNode(expectedElement);
+                diff.addDiff(i, jsonMatcher.diff(path.add(Path.PathItem.of(i)), expectedElement, expectedElement));
+            } else {
+                expectedMissing.add(new IndexedJsonNode(i, expectedArrayNode.get(i)));
+            }
+        }
+        for (int i = 0; i < actualArrayNode.size(); i++) {
+            var actualElement = actualArrayNode.get(i);
+            if (expectedNodeCounter.containsNode(actualElement)) {
+                expectedNodeCounter.removeNode(actualElement);
+            } else {
+                actualMissing.add(new IndexedJsonNode(i, actualArrayNode.get(i)));
+            }
+        }
+        return new MismatchPair<>(expectedMissing, actualMissing);
+    }
+
+    private NodeCounter getElementsWithCount(Iterator<JsonNode> elements) {
+        var nodeCounter = new NodeCounter();
+        elements.forEachRemaining(nodeCounter::addNode);
+        return nodeCounter;
+    }
+
+    private static class MismatchPair<K, V> {
+        private final K expectedMissing;
+        private final V actualMissing;
+
+        public MismatchPair(K expectedMissing, V actualMissing) {
+            this.expectedMissing = expectedMissing;
+            this.actualMissing = actualMissing;
+        }
+    }
+
+    private static class IndexedJsonNode {
+        private final int index;
+        private final JsonNode jsonNode;
+
+        public IndexedJsonNode(int index, JsonNode jsonNode) {
+            this.index = index;
+            this.jsonNode = jsonNode;
+        }
+    }
+
+    private static class NodeCounter {
+        private Map<JsonNode, Integer> nodeCounter = new HashMap<>();
+
+        public void addNode(JsonNode node) {
+            nodeCounter.compute(node, (key, prevValue) -> (prevValue == null ? 0 : prevValue) + 1);
+        }
+
+        public void removeNode(JsonNode node) {
+            nodeCounter.put(node, nodeCounter.get(node) - 1);
+            if (nodeCounter.get(node) == 0) {
+                nodeCounter.remove(node);
+            }
+        }
+
+        public boolean containsNode(JsonNode node) {
+            return nodeCounter.containsKey(node);
+        }
     }
 }

--- a/src/test/java/com/deblock/jsondiff/Sample.java
+++ b/src/test/java/com/deblock/jsondiff/Sample.java
@@ -21,7 +21,7 @@ public class Sample {
         final var jsondiff = DiffGenerator.diff(expectedJson, receivedJson, jsonMatcher);
 
         // use the viewer to collect diff data
-        final var errorsResult= PatchDiffViewer.from(jsondiff);
+        final var errorsResult = PatchDiffViewer.from(jsondiff);
 
         // print the diff result
         System.out.println(errorsResult);

--- a/src/test/java/com/deblock/jsondiff/matcher/LenientJsonArrayPartialMatcherTest.java
+++ b/src/test/java/com/deblock/jsondiff/matcher/LenientJsonArrayPartialMatcherTest.java
@@ -117,6 +117,42 @@ class LenientJsonArrayPartialMatcherTest {
                 .validate(result);
     }
 
+    @Test
+    void shouldWorkWithDuplicatedArrayItemsOnExpected() {
+        final var expected = new ArrayNode(null, List.of(TextNode.valueOf("a"), TextNode.valueOf("a"), TextNode.valueOf("b")));
+        final var actual = new ArrayNode(null, List.of(TextNode.valueOf("a"), TextNode.valueOf("b")));
+        final var jsonMatcher = Mockito.mock(JsonMatcher.class);
+        Mockito.when(jsonMatcher.diff(any(), any(), any())).thenAnswer(this::matchByEquality);
+
+        final var result = new LenientJsonArrayPartialMatcher().jsonDiff(path, expected, actual, jsonMatcher);
+
+        assertEquals(path, result.path());
+        new JsonDiffAsserter()
+                .assertSimilarityRate(66.66)
+                .assertMatchingProperty(path.add(Path.PathItem.of(0)))
+                .assertMissingProperty(path.add(Path.PathItem.of(1)))
+                .assertMatchingProperty(path.add(Path.PathItem.of(2)))
+                .validate(result);
+    }
+
+    @Test
+    void shouldWorkWithDuplicatedArrayItemsOnActual() {
+        final var expected = new ArrayNode(null, List.of(TextNode.valueOf("a"), TextNode.valueOf("b")));
+        final var actual = new ArrayNode(null, List.of(TextNode.valueOf("a"), TextNode.valueOf("a"), TextNode.valueOf("b")));
+        final var jsonMatcher = Mockito.mock(JsonMatcher.class);
+        Mockito.when(jsonMatcher.diff(any(), any(), any())).thenAnswer(this::matchByEquality);
+
+        final var result = new LenientJsonArrayPartialMatcher().jsonDiff(path, expected, actual, jsonMatcher);
+
+        assertEquals(path, result.path());
+        new JsonDiffAsserter()
+                .assertSimilarityRate(66.66)
+                .assertMatchingProperty(path.add(Path.PathItem.of(0)))
+                .assertExtraProperty(path.add(Path.PathItem.of(1)))
+                .assertMatchingProperty(path.add(Path.PathItem.of(1)))
+                .validate(result);
+    }
+
     private JsonDiff matchByEquality(org.mockito.invocation.InvocationOnMock args) {
         if (args.getArgument(1).equals(args.getArgument(2))) {
             return fullMatchJsonDiff(args.getArgument(0));


### PR DESCRIPTION
LenientJsonArrayPartialMatcher performs a comparison of each element in the expected array node with each element in the actual array node, resulting in n^2 complexity for calculating the similarity score before identifying the best matching pairs for comparison. [Here is the code link](https://github.com/deblockt/json-diff/blob/416e8f8a0f75d74e1ca417577445d14ea1b515fd/src/main/java/com/deblock/jsondiff/matcher/LenientJsonArrayPartialMatcher.java#L18).

I identified an opportunity for optimization in this process. By filtering out identical elements [code link](https://github.com/aymar99/json-diff/blob/d5067d49d5d2ea16298feeda338b6f73911414d8/src/main/java/com/deblock/jsondiff/matcher/LenientJsonArrayPartialMatcher.java#L17) from both the expected and actual arrays before applying the n^2 similarity score calculation, we can significantly reduce the complexity. In scenarios where there are only a few mismatches between the expected and actual arrays, this optimization ensures that the n^2 complexity is only applied to those differing elements. The worst-case scenario of n^2 for all elements in the array occurs only if none of the elements match.

For smaller JSONs, the implementation may not exhibit a noticeable difference. However, during testing with larger JSONs containing hundreds of array elements, a significant performance improvement becomes apparent. I have tested this enhancement and created a pull request. I would appreciate it if you could review the pull request and share your thoughts!

The base of this MR come from @aymar99 and the PR #18. 
