### PR TITLE
Let DiffGenerator be able to use a pre-configured ObjectMapper 

### DIFF
--- a/src/main/java/com/deblock/jsondiff/DiffGenerator.java
+++ b/src/main/java/com/deblock/jsondiff/DiffGenerator.java
@@ -11,22 +11,43 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 public class DiffGenerator {
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final ObjectMapper DEFAULT_OBJECT_MAPPER = new ObjectMapper();
+    private final ObjectMapper objectMapper;
+    private final JsonMatcher jsonMatcher;
 
-    public static JsonDiff diff(String expected, String actual, JsonMatcher jsonMatcher) {
+    public DiffGenerator(ObjectMapper objectMapper, JsonMatcher jsonMatcher)
+    {
+        this.objectMapper = objectMapper;
+        this.jsonMatcher = jsonMatcher;
+    }
+
+    public DiffGenerator(JsonMatcher jsonMatcher)
+    {
+        this(DEFAULT_OBJECT_MAPPER, jsonMatcher);
+    }
+
+    public JsonDiff diff(String expected, String actual) {
         return jsonMatcher.diff(Path.ROOT, read(expected), read(actual));
     }
 
-    public static List<JsonDiff> diff(String expected, List<String> actualValues, JsonMatcher jsonMatcher) {
+    public List<JsonDiff> diff(String expected, List<String> actualValues) {
         final var expectedObject = read(expected);
         return actualValues.stream()
-            .map(actual -> jsonMatcher.diff(Path.ROOT, expectedObject, read(actual)))
-            .collect(Collectors.toList());
+                           .map(actual -> jsonMatcher.diff(Path.ROOT, expectedObject, read(actual)))
+                           .collect(Collectors.toList());
     }
 
-    private static JsonNode read(String json) {
+    public static JsonDiff diff(String expected, String actual, JsonMatcher jsonMatcher) {
+        return new DiffGenerator(jsonMatcher).diff(expected, actual);
+    }
+
+    public static List<JsonDiff> diff(String expected, List<String> actualValues, JsonMatcher jsonMatcher) {
+        return new DiffGenerator(jsonMatcher).diff(expected, actualValues);
+    }
+
+    private JsonNode read(String json) {
         try {
-            return OBJECT_MAPPER.readTree(json);
+            return objectMapper.readTree(json);
         } catch (JsonProcessingException e) {
             throw new JsonReadException(e);
         }


### PR DESCRIPTION
I want to be able to use an `ObjectMapper` that is shared with other code in my application, and which may have configuration set up other than the default one.

The existing static API of `DIffGenerator` has been maintained, but it can also be constructed as an instance.