### PR TITLE
feat: upgrade to Jackson 3.x and Java 21

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,10 +14,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - name: Set up JDK 11
+      - name: Set up JDK 21
         uses: actions/setup-java@v3
         with:
-          java-version: '11'
+          java-version: '21'
           distribution: 'temurin'
           server-id: github
           settings-path: ${{ github.workspace }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - name: Set up JDK 11
+      - name: Set up JDK 21
         uses: actions/setup-java@v3
         with:
-          java-version: '11'
+          java-version: '21'
           distribution: 'temurin'
       - name: Setup gradle
         uses: gradle/gradle-build-action@67421db6bd0bf253fb4bd25b31ebb98943c375e1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,61 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Build Commands
+
+```bash
+# Build the project
+./gradlew build
+
+# Run all tests
+./gradlew test
+
+# Run a single test class
+./gradlew test --tests "com.deblock.jsondiff.matcher.LenientJsonArrayPartialMatcherTest"
+
+# Run a single test method
+./gradlew test --tests "com.deblock.jsondiff.DiffGeneratorTest.singleDiff"
+
+# Create JAR
+./gradlew jar
+
+# Publish to Maven local
+./gradlew publishToMavenLocal
+```
+
+## Architecture
+
+This library compares two JSON documents and produces a diff with a similarity score (0-100).
+
+### Core Components
+
+**Entry Point:** `DiffGenerator.diff(expectedJson, actualJson, jsonMatcher)` parses JSON strings and delegates to matchers.
+
+**Matcher Layer** (`com.deblock.jsondiff.matcher`):
+- `CompositeJsonMatcher` - Combines different matchers for objects, arrays, and primitives
+- `PartialJsonMatcher<T>` - Interface for type-specific matching strategies
+- Two modes available:
+  - **Strict:** `StrictJsonObjectPartialMatcher`, `StrictJsonArrayPartialMatcher`, `StrictPrimitivePartialMatcher`
+  - **Lenient:** `LenientJsonObjectPartialMatcher` (ignores extra properties), `LenientJsonArrayPartialMatcher` (ignores order/extra items), `LenientNumberPrimitivePartialMatcher` (10.0 == 10)
+
+**Diff Representation** (`com.deblock.jsondiff.diff`):
+- `JsonDiff` - Interface with `similarityRate()` and `display(viewer)` methods
+- `JsonObjectDiff` - Object comparison result (similarity = 60% structure + 40% values)
+- `JsonArrayDiff` - Array comparison result (similarity = average of matched items)
+- `MatchedPrimaryDiff` / `UnMatchedPrimaryDiff` - Primitive comparison results
+
+**Viewer Layer** (`com.deblock.jsondiff.viewer`):
+- `JsonDiffViewer` - Visitor interface for consuming diff results
+- `OnlyErrorDiffViewer` - Human-readable error list output
+- `PatchDiffViewer` - Unified diff format output
+
+### Design Patterns
+
+- **Visitor Pattern:** JsonDiffViewer consumes JsonDiff via `display(viewer)` method
+- **Strategy Pattern:** Different PartialJsonMatcher implementations for different comparison modes
+- **Composite Pattern:** CompositeJsonMatcher combines object/array/primitive matchers
+
+### Path Tracking
+
+`Path` class tracks JSON location (e.g., `$.property.0.subproperty`) using `PathItem` subclasses (`ObjectProperty`, `ArrayIndex`).

--- a/build.gradle
+++ b/build.gradle
@@ -20,9 +20,10 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.15.2'
-    testImplementation 'org.junit.jupiter:junit-jupiter:5.7.1'
-    testImplementation 'org.mockito:mockito-core:3.8.0'
+    implementation 'tools.jackson.core:jackson-databind:3.0.3'
+    testImplementation platform('org.junit:junit-bom:5.10.2')
+    testImplementation 'org.junit.jupiter:junit-jupiter'
+    testImplementation 'org.mockito:mockito-core:5.21.0'
 }
 
 group = 'io.github.deblockt'
@@ -50,8 +51,8 @@ java {
     withJavadocJar()
     withSourcesJar()
 
-    sourceCompatibility = JavaLanguageVersion.of(11)
-    targetCompatibility = JavaLanguageVersion.of(11)
+    sourceCompatibility = JavaLanguageVersion.of(21)
+    targetCompatibility = JavaLanguageVersion.of(21)
 }
 
 test {

--- a/src/main/java/com/deblock/jsondiff/DiffGenerator.java
+++ b/src/main/java/com/deblock/jsondiff/DiffGenerator.java
@@ -3,9 +3,9 @@ package com.deblock.jsondiff;
 import com.deblock.jsondiff.diff.JsonDiff;
 import com.deblock.jsondiff.matcher.JsonMatcher;
 import com.deblock.jsondiff.matcher.Path;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -27,7 +27,7 @@ public class DiffGenerator {
     private static JsonNode read(String json) {
         try {
             return OBJECT_MAPPER.readTree(json);
-        } catch (JsonProcessingException e) {
+        } catch (JacksonException e) {
             throw new JsonReadException(e);
         }
     }

--- a/src/main/java/com/deblock/jsondiff/diff/JsonArrayDiff.java
+++ b/src/main/java/com/deblock/jsondiff/diff/JsonArrayDiff.java
@@ -2,7 +2,7 @@ package com.deblock.jsondiff.diff;
 
 import com.deblock.jsondiff.matcher.Path;
 import com.deblock.jsondiff.viewer.JsonDiffViewer;
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/src/main/java/com/deblock/jsondiff/diff/JsonObjectDiff.java
+++ b/src/main/java/com/deblock/jsondiff/diff/JsonObjectDiff.java
@@ -2,8 +2,8 @@ package com.deblock.jsondiff.diff;
 
 import com.deblock.jsondiff.matcher.Path;
 import com.deblock.jsondiff.viewer.JsonDiffViewer;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.ObjectNode;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/src/main/java/com/deblock/jsondiff/diff/MatchedPrimaryDiff.java
+++ b/src/main/java/com/deblock/jsondiff/diff/MatchedPrimaryDiff.java
@@ -2,7 +2,7 @@ package com.deblock.jsondiff.diff;
 
 import com.deblock.jsondiff.matcher.Path;
 import com.deblock.jsondiff.viewer.JsonDiffViewer;
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 
 public class MatchedPrimaryDiff implements JsonDiff {
     private final JsonNode value;

--- a/src/main/java/com/deblock/jsondiff/diff/UnMatchedPrimaryDiff.java
+++ b/src/main/java/com/deblock/jsondiff/diff/UnMatchedPrimaryDiff.java
@@ -2,7 +2,7 @@ package com.deblock.jsondiff.diff;
 
 import com.deblock.jsondiff.matcher.Path;
 import com.deblock.jsondiff.viewer.JsonDiffViewer;
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 
 public class UnMatchedPrimaryDiff implements JsonDiff {
     private final JsonNode expectedValue;

--- a/src/main/java/com/deblock/jsondiff/matcher/CompositeJsonMatcher.java
+++ b/src/main/java/com/deblock/jsondiff/matcher/CompositeJsonMatcher.java
@@ -1,10 +1,10 @@
 package com.deblock.jsondiff.matcher;
 
 import com.deblock.jsondiff.diff.*;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.fasterxml.jackson.databind.node.ValueNode;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.node.ValueNode;
 
 public class CompositeJsonMatcher implements JsonMatcher {
     private final PartialJsonMatcher<ArrayNode> jsonArrayPartialMatcher;
@@ -23,12 +23,12 @@ public class CompositeJsonMatcher implements JsonMatcher {
 
     @Override
     public JsonDiff diff(Path path, JsonNode expected, JsonNode received) {
-        if (expected instanceof ObjectNode  && received instanceof ObjectNode) {
-            return this.jsonObjectPartialMatcher.jsonDiff(path, (ObjectNode) expected, (ObjectNode) received, this);
-        } else if (expected instanceof ArrayNode && received instanceof ArrayNode) {
-            return this.jsonArrayPartialMatcher.jsonDiff(path, (ArrayNode) expected, (ArrayNode) received, this);
-        } else if (expected instanceof ValueNode && received instanceof ValueNode){
-            return this.primitivePartialMatcher.jsonDiff(path, (ValueNode) expected, (ValueNode) received, this);
+        if (expected instanceof ObjectNode expectedObjectNode  && received instanceof ObjectNode receivedObjectNode) {
+            return this.jsonObjectPartialMatcher.jsonDiff(path, expectedObjectNode, receivedObjectNode, this);
+        } else if (expected instanceof ArrayNode expectedArrayNode && received instanceof ArrayNode receivedArrayNode) {
+            return this.jsonArrayPartialMatcher.jsonDiff(path, expectedArrayNode, receivedArrayNode, this);
+        } else if (expected instanceof ValueNode expectedValueNode && received instanceof ValueNode receivedValueNode){
+            return this.primitivePartialMatcher.jsonDiff(path, expectedValueNode, receivedValueNode, this);
         } else {
             return new UnMatchedPrimaryDiff(path, expected, received);
         }

--- a/src/main/java/com/deblock/jsondiff/matcher/JsonMatcher.java
+++ b/src/main/java/com/deblock/jsondiff/matcher/JsonMatcher.java
@@ -1,7 +1,7 @@
 package com.deblock.jsondiff.matcher;
 
 import com.deblock.jsondiff.diff.*;
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 
 public interface JsonMatcher {
 

--- a/src/main/java/com/deblock/jsondiff/matcher/LenientJsonArrayPartialMatcher.java
+++ b/src/main/java/com/deblock/jsondiff/matcher/LenientJsonArrayPartialMatcher.java
@@ -2,16 +2,10 @@ package com.deblock.jsondiff.matcher;
 
 import com.deblock.jsondiff.diff.JsonArrayDiff;
 import com.deblock.jsondiff.diff.JsonDiff;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.ArrayNode;
 
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.stream.Collectors;
 
 public class LenientJsonArrayPartialMatcher implements PartialJsonMatcher<ArrayNode> {
@@ -99,9 +93,9 @@ public class LenientJsonArrayPartialMatcher implements PartialJsonMatcher<ArrayN
         return new MismatchPair<>(expectedMissing, actualMissing);
     }
 
-    private NodeCounter getElementsWithCount(Iterator<JsonNode> elements) {
+    private NodeCounter getElementsWithCount(Collection<JsonNode> elements) {
         var nodeCounter = new NodeCounter();
-        elements.forEachRemaining(nodeCounter::addNode);
+        elements.forEach(nodeCounter::addNode);
         return nodeCounter;
     }
 

--- a/src/main/java/com/deblock/jsondiff/matcher/LenientJsonObjectPartialMatcher.java
+++ b/src/main/java/com/deblock/jsondiff/matcher/LenientJsonObjectPartialMatcher.java
@@ -2,7 +2,7 @@ package com.deblock.jsondiff.matcher;
 
 import com.deblock.jsondiff.diff.JsonDiff;
 import com.deblock.jsondiff.diff.JsonObjectDiff;
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.node.ObjectNode;
 
 public class LenientJsonObjectPartialMatcher implements PartialJsonMatcher<ObjectNode> {
 
@@ -10,8 +10,8 @@ public class LenientJsonObjectPartialMatcher implements PartialJsonMatcher<Objec
     public JsonDiff jsonDiff(Path path, ObjectNode expectedJson, ObjectNode receivedJson, JsonMatcher jsonMatcher) {
         final var jsonDiff = new JsonObjectDiff(path);
 
-        expectedJson.fields()
-            .forEachRemaining(entry -> {
+        expectedJson.properties()
+            .forEach(entry -> {
                 final var expectedPropertyName = entry.getKey();
                 final var expectedValue = entry.getValue();
                 final var receivedValue = receivedJson.get(expectedPropertyName);

--- a/src/main/java/com/deblock/jsondiff/matcher/LenientNumberPrimitivePartialMatcher.java
+++ b/src/main/java/com/deblock/jsondiff/matcher/LenientNumberPrimitivePartialMatcher.java
@@ -3,8 +3,8 @@ package com.deblock.jsondiff.matcher;
 import com.deblock.jsondiff.diff.JsonDiff;
 import com.deblock.jsondiff.diff.MatchedPrimaryDiff;
 import com.deblock.jsondiff.diff.UnMatchedPrimaryDiff;
-import com.fasterxml.jackson.databind.node.NumericNode;
-import com.fasterxml.jackson.databind.node.ValueNode;
+import tools.jackson.databind.node.NumericNode;
+import tools.jackson.databind.node.ValueNode;
 
 public class LenientNumberPrimitivePartialMatcher implements PartialJsonMatcher<ValueNode> {
     private final PartialJsonMatcher<ValueNode> delegated;
@@ -16,12 +16,7 @@ public class LenientNumberPrimitivePartialMatcher implements PartialJsonMatcher<
     @Override
     public JsonDiff jsonDiff(Path path, ValueNode expectedValue, ValueNode receivedValue, JsonMatcher jsonMatcher) {
         if (expectedValue instanceof NumericNode && receivedValue instanceof NumericNode) {
-            final var expectedIntValue = expectedValue.intValue();
-            final var actualIntValue = receivedValue.intValue();
-            final var expectedDecimalValue = receivedValue.doubleValue() % 1;
-            final var actualDecimalValue = expectedValue.doubleValue() % 1;
-
-            if (expectedIntValue != actualIntValue || expectedDecimalValue != actualDecimalValue) {
+            if (expectedValue.decimalValue().compareTo(receivedValue.decimalValue()) != 0) {
                 return new UnMatchedPrimaryDiff(path, expectedValue, receivedValue);
             } else {
                 return new MatchedPrimaryDiff(path, expectedValue);

--- a/src/main/java/com/deblock/jsondiff/matcher/PartialJsonMatcher.java
+++ b/src/main/java/com/deblock/jsondiff/matcher/PartialJsonMatcher.java
@@ -1,7 +1,7 @@
 package com.deblock.jsondiff.matcher;
 
 import com.deblock.jsondiff.diff.JsonDiff;
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 
 public interface PartialJsonMatcher<T extends JsonNode> {
     JsonDiff jsonDiff(Path path, T expectedJson, T receivedJson, JsonMatcher jsonMatcher);

--- a/src/main/java/com/deblock/jsondiff/matcher/StrictJsonArrayPartialMatcher.java
+++ b/src/main/java/com/deblock/jsondiff/matcher/StrictJsonArrayPartialMatcher.java
@@ -2,7 +2,7 @@ package com.deblock.jsondiff.matcher;
 
 import com.deblock.jsondiff.diff.JsonArrayDiff;
 import com.deblock.jsondiff.diff.JsonDiff;
-import com.fasterxml.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.node.ArrayNode;
 
 import java.util.Comparator;
 import java.util.HashMap;

--- a/src/main/java/com/deblock/jsondiff/matcher/StrictJsonObjectPartialMatcher.java
+++ b/src/main/java/com/deblock/jsondiff/matcher/StrictJsonObjectPartialMatcher.java
@@ -2,20 +2,16 @@ package com.deblock.jsondiff.matcher;
 
 import com.deblock.jsondiff.diff.JsonDiff;
 import com.deblock.jsondiff.diff.JsonObjectDiff;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-
-import java.util.stream.Collectors;
-import java.util.stream.StreamSupport;
+import tools.jackson.databind.node.ObjectNode;
 
 public class StrictJsonObjectPartialMatcher implements PartialJsonMatcher<ObjectNode> {
 
     @Override
     public JsonDiff jsonDiff(Path path, ObjectNode expectedJson, ObjectNode receivedJson, JsonMatcher jsonMatcher) {
         final var jsonDiff = new JsonObjectDiff(path);
-        final var receivedJsonFields = StreamSupport.stream(((Iterable<String>) receivedJson::fieldNames).spliterator(), false).collect(Collectors.toSet());
 
-        expectedJson.fields()
-            .forEachRemaining(entry -> {
+        expectedJson.properties()
+            .forEach(entry -> {
                 final var expectedPropertyName = entry.getKey();
                 final var expectedValue = entry.getValue();
                 final var receivedValue = receivedJson.get(expectedPropertyName);
@@ -26,12 +22,10 @@ public class StrictJsonObjectPartialMatcher implements PartialJsonMatcher<Object
                     final var diff = jsonMatcher.diff(path.add(Path.PathItem.of(expectedPropertyName)), expectedValue, receivedValue);
                     jsonDiff.addPropertyDiff(expectedPropertyName, diff);
                 }
-                receivedJsonFields.remove(expectedPropertyName);
             });
 
-
-        receivedJson.fields()
-                .forEachRemaining(entry -> {
+        receivedJson.properties()
+                .forEach(entry -> {
                     final var receivedPropertyName = entry.getKey();
                     final var receivedPropertyValue = entry.getValue();
                     final var expectedValue = expectedJson.get(receivedPropertyName);

--- a/src/main/java/com/deblock/jsondiff/matcher/StrictPrimitivePartialMatcher.java
+++ b/src/main/java/com/deblock/jsondiff/matcher/StrictPrimitivePartialMatcher.java
@@ -3,7 +3,7 @@ package com.deblock.jsondiff.matcher;
 import com.deblock.jsondiff.diff.JsonDiff;
 import com.deblock.jsondiff.diff.MatchedPrimaryDiff;
 import com.deblock.jsondiff.diff.UnMatchedPrimaryDiff;
-import com.fasterxml.jackson.databind.node.ValueNode;
+import tools.jackson.databind.node.ValueNode;
 
 import java.util.Objects;
 

--- a/src/main/java/com/deblock/jsondiff/viewer/JsonDiffViewer.java
+++ b/src/main/java/com/deblock/jsondiff/viewer/JsonDiffViewer.java
@@ -2,7 +2,7 @@ package com.deblock.jsondiff.viewer;
 
 import com.deblock.jsondiff.diff.JsonDiff;
 import com.deblock.jsondiff.matcher.Path;
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 
 public interface JsonDiffViewer {
 

--- a/src/main/java/com/deblock/jsondiff/viewer/OnlyErrorDiffViewer.java
+++ b/src/main/java/com/deblock/jsondiff/viewer/OnlyErrorDiffViewer.java
@@ -2,7 +2,7 @@ package com.deblock.jsondiff.viewer;
 
 import com.deblock.jsondiff.diff.JsonDiff;
 import com.deblock.jsondiff.matcher.Path;
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 
 /**
  * List all error on a string

--- a/src/main/java/com/deblock/jsondiff/viewer/PatchDiffViewer.java
+++ b/src/main/java/com/deblock/jsondiff/viewer/PatchDiffViewer.java
@@ -2,7 +2,7 @@ package com.deblock.jsondiff.viewer;
 
 import com.deblock.jsondiff.diff.JsonDiff;
 import com.deblock.jsondiff.matcher.Path;
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 
 import java.util.ArrayList;
 import java.util.HashMap;

--- a/src/test/java/com/deblock/jsondiff/DiffGeneratorTest.java
+++ b/src/test/java/com/deblock/jsondiff/DiffGeneratorTest.java
@@ -3,9 +3,9 @@ package com.deblock.jsondiff;
 import com.deblock.jsondiff.diff.JsonDiff;
 import com.deblock.jsondiff.matcher.JsonMatcher;
 import com.deblock.jsondiff.matcher.Path;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.fasterxml.jackson.databind.node.TextNode;
+import tools.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.node.StringNode;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -34,7 +34,7 @@ public class DiffGeneratorTest {
         final var receivedJson = "\"string1\"";
         final var matcher = Mockito.mock(JsonMatcher.class);
         final var diff = Mockito.mock(JsonDiff.class);
-        Mockito.when(matcher.diff(Path.ROOT, TextNode.valueOf("string1"), TextNode.valueOf("string1"))).thenReturn(diff);
+        Mockito.when(matcher.diff(Path.ROOT, StringNode.valueOf("string1"), StringNode.valueOf("string1"))).thenReturn(diff);
 
         final var result = DiffGenerator.diff(expectedJson, receivedJson, matcher);
 
@@ -45,7 +45,7 @@ public class DiffGeneratorTest {
     public void shouldSupportArrayDiff() {
         final var expectedJson = "[\"string1\"]";
         final var receivedJson = "[\"string1\"]";
-        final var jsonNode = new ArrayNode(null, List.of(TextNode.valueOf("string1")));
+        final var jsonNode = new ArrayNode(null, List.of(StringNode.valueOf("string1")));
         final var matcher = Mockito.mock(JsonMatcher.class);
         final var diff = Mockito.mock(JsonDiff.class);
         Mockito.when(matcher.diff(Path.ROOT, jsonNode, jsonNode)).thenReturn(diff);
@@ -59,7 +59,7 @@ public class DiffGeneratorTest {
     public void shouldSupportObjectDiff() {
         final var expectedJson = "{\"a\": \"string1\"}";
         final var receivedJson = "{\"a\": \"string1\"}";
-        final var jsonNode = new ObjectNode(null, Map.of("a", TextNode.valueOf("string1")));
+        final var jsonNode = new ObjectNode(null, Map.of("a", StringNode.valueOf("string1")));
         final var matcher = Mockito.mock(JsonMatcher.class);
         final var diff = Mockito.mock(JsonDiff.class);
         Mockito.when(matcher.diff(Path.ROOT, jsonNode, jsonNode)).thenReturn(diff);

--- a/src/test/java/com/deblock/jsondiff/matcher/CompositeJsonMatcherTest.java
+++ b/src/test/java/com/deblock/jsondiff/matcher/CompositeJsonMatcherTest.java
@@ -1,7 +1,7 @@
 package com.deblock.jsondiff.matcher;
 
 import com.deblock.jsondiff.diff.JsonDiff;
-import com.fasterxml.jackson.databind.node.*;
+import tools.jackson.databind.node.*;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
@@ -50,7 +50,7 @@ public class CompositeJsonMatcherTest {
 
     @Test
     public void shouldCallThePrimitiveMatcherIfTheTwoObjectAreValue() {
-        final var value1 = TextNode.valueOf("");
+        final var value1 = StringNode.valueOf("");
         final var value2 = IntNode.valueOf(10);
 
         final var primitiveMatcher = (PartialJsonMatcher<ValueNode>) Mockito.mock(PartialJsonMatcher.class);
@@ -69,7 +69,7 @@ public class CompositeJsonMatcherTest {
 
     @Test
     public void shouldReturnANonMatchWhenTypesAreDifferent() {
-        final var value1 = TextNode.valueOf("");
+        final var value1 = StringNode.valueOf("");
         final var value2 = new ObjectNode(null);
 
         final var compositeMatcher = new CompositeJsonMatcher(

--- a/src/test/java/com/deblock/jsondiff/matcher/JsonDiffAsserter.java
+++ b/src/test/java/com/deblock/jsondiff/matcher/JsonDiffAsserter.java
@@ -2,7 +2,7 @@ package com.deblock.jsondiff.matcher;
 
 import com.deblock.jsondiff.diff.JsonDiff;
 import com.deblock.jsondiff.viewer.JsonDiffViewer;
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 
 import java.util.ArrayList;
 import java.util.Collection;

--- a/src/test/java/com/deblock/jsondiff/matcher/LenientJsonArrayPartialMatcherTest.java
+++ b/src/test/java/com/deblock/jsondiff/matcher/LenientJsonArrayPartialMatcherTest.java
@@ -2,8 +2,8 @@ package com.deblock.jsondiff.matcher;
 
 import com.deblock.jsondiff.diff.JsonDiff;
 import com.deblock.jsondiff.viewer.JsonDiffViewer;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.TextNode;
+import tools.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.node.StringNode;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
@@ -17,8 +17,8 @@ class LenientJsonArrayPartialMatcherTest {
 
     @Test
     void shouldReturnFullMatchWhenAllItemsAreFound() {
-        final var array1 = new ArrayNode(null, List.of(TextNode.valueOf("a"), TextNode.valueOf("b")));
-        final var array2 = new ArrayNode(null, List.of(TextNode.valueOf("a"), TextNode.valueOf("b")));
+        final var array1 = new ArrayNode(null, List.of(StringNode.valueOf("a"), StringNode.valueOf("b")));
+        final var array2 = new ArrayNode(null, List.of(StringNode.valueOf("a"), StringNode.valueOf("b")));
         final var jsonMatcher = Mockito.mock(JsonMatcher.class);
         Mockito.when(jsonMatcher.diff(any(), any(), any())).thenAnswer(this::matchByEquality);
 
@@ -34,8 +34,8 @@ class LenientJsonArrayPartialMatcherTest {
 
     @Test
     void shouldReturnFullMatchWhenAllItemsAreFoundWithBadOrder() {
-        final var array1 = new ArrayNode(null, List.of(TextNode.valueOf("a"), TextNode.valueOf("b")));
-        final var array2 = new ArrayNode(null, List.of(TextNode.valueOf("b"), TextNode.valueOf("a")));
+        final var array1 = new ArrayNode(null, List.of(StringNode.valueOf("a"), StringNode.valueOf("b")));
+        final var array2 = new ArrayNode(null, List.of(StringNode.valueOf("b"), StringNode.valueOf("a")));
         final var jsonMatcher = Mockito.mock(JsonMatcher.class);
         Mockito.when(jsonMatcher.diff(any(), any(), any())).thenAnswer(this::matchByEquality);
 
@@ -66,8 +66,8 @@ class LenientJsonArrayPartialMatcherTest {
 
     @Test
     void shouldReturnNoMatchWhenSameNumberItemWithNoMatch() {
-        final var array1 = new ArrayNode(null, List.of(TextNode.valueOf("a"), TextNode.valueOf("b")));
-        final var array2 = new ArrayNode(null, List.of(TextNode.valueOf("c"), TextNode.valueOf("d")));
+        final var array1 = new ArrayNode(null, List.of(StringNode.valueOf("a"), StringNode.valueOf("b")));
+        final var array2 = new ArrayNode(null, List.of(StringNode.valueOf("c"), StringNode.valueOf("d")));
         final var jsonMatcher = Mockito.mock(JsonMatcher.class);
         Mockito.when(jsonMatcher.diff(any(), any(), any())).thenAnswer(this::matchByEquality);
 
@@ -83,8 +83,8 @@ class LenientJsonArrayPartialMatcherTest {
 
     @Test
     void shouldReturnPartialMatchWhenMissingItem() {
-        final var array1 = new ArrayNode(null, List.of(TextNode.valueOf("a"), TextNode.valueOf("b")));
-        final var array2 = new ArrayNode(null, List.of(TextNode.valueOf("b")));
+        final var array1 = new ArrayNode(null, List.of(StringNode.valueOf("a"), StringNode.valueOf("b")));
+        final var array2 = new ArrayNode(null, List.of(StringNode.valueOf("b")));
         final var jsonMatcher = Mockito.mock(JsonMatcher.class);
         Mockito.when(jsonMatcher.diff(any(), any(), any())).thenAnswer(this::matchByEquality);
 
@@ -100,8 +100,8 @@ class LenientJsonArrayPartialMatcherTest {
 
     @Test
     void shouldReturnPartialMatchWhenExtraItems() {
-        final var array1 = new ArrayNode(null, List.of(TextNode.valueOf("a"), TextNode.valueOf("c")));
-        final var array2 = new ArrayNode(null, List.of(TextNode.valueOf("a"), TextNode.valueOf("b"), TextNode.valueOf("c"), TextNode.valueOf("d")));
+        final var array1 = new ArrayNode(null, List.of(StringNode.valueOf("a"), StringNode.valueOf("c")));
+        final var array2 = new ArrayNode(null, List.of(StringNode.valueOf("a"), StringNode.valueOf("b"), StringNode.valueOf("c"), StringNode.valueOf("d")));
         final var jsonMatcher = Mockito.mock(JsonMatcher.class);
         Mockito.when(jsonMatcher.diff(any(), any(), any())).thenAnswer(this::matchByEquality);
 
@@ -119,8 +119,8 @@ class LenientJsonArrayPartialMatcherTest {
 
     @Test
     void shouldWorkWithDuplicatedArrayItemsOnExpected() {
-        final var expected = new ArrayNode(null, List.of(TextNode.valueOf("a"), TextNode.valueOf("a"), TextNode.valueOf("b")));
-        final var actual = new ArrayNode(null, List.of(TextNode.valueOf("a"), TextNode.valueOf("b")));
+        final var expected = new ArrayNode(null, List.of(StringNode.valueOf("a"), StringNode.valueOf("a"), StringNode.valueOf("b")));
+        final var actual = new ArrayNode(null, List.of(StringNode.valueOf("a"), StringNode.valueOf("b")));
         final var jsonMatcher = Mockito.mock(JsonMatcher.class);
         Mockito.when(jsonMatcher.diff(any(), any(), any())).thenAnswer(this::matchByEquality);
 
@@ -137,8 +137,8 @@ class LenientJsonArrayPartialMatcherTest {
 
     @Test
     void shouldWorkWithDuplicatedArrayItemsOnActual() {
-        final var expected = new ArrayNode(null, List.of(TextNode.valueOf("a"), TextNode.valueOf("b")));
-        final var actual = new ArrayNode(null, List.of(TextNode.valueOf("a"), TextNode.valueOf("a"), TextNode.valueOf("b")));
+        final var expected = new ArrayNode(null, List.of(StringNode.valueOf("a"), StringNode.valueOf("b")));
+        final var actual = new ArrayNode(null, List.of(StringNode.valueOf("a"), StringNode.valueOf("a"), StringNode.valueOf("b")));
         final var jsonMatcher = Mockito.mock(JsonMatcher.class);
         Mockito.when(jsonMatcher.diff(any(), any(), any())).thenAnswer(this::matchByEquality);
 

--- a/src/test/java/com/deblock/jsondiff/matcher/LenientJsonObjectPartialMatcherTest.java
+++ b/src/test/java/com/deblock/jsondiff/matcher/LenientJsonObjectPartialMatcherTest.java
@@ -2,8 +2,8 @@ package com.deblock.jsondiff.matcher;
 
 import com.deblock.jsondiff.diff.JsonDiff;
 import com.deblock.jsondiff.viewer.JsonDiffViewer;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.fasterxml.jackson.databind.node.TextNode;
+import tools.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.node.StringNode;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
@@ -32,8 +32,8 @@ class LenientJsonObjectPartialMatcherTest {
     @Test
     void shouldReturnNonMachIfAllPropertiesAreNotFound() {
         final var object1 = new ObjectNode(null, Map.of(
-            "a", TextNode.valueOf("a"),
-            "b", TextNode.valueOf("b")
+            "a", StringNode.valueOf("a"),
+            "b", StringNode.valueOf("b")
         ));
         final var object2 = new ObjectNode(null);
 
@@ -50,12 +50,12 @@ class LenientJsonObjectPartialMatcherTest {
     @Test
     void shouldReturnNonMatchingPropertyIfAllPropertiesAreFoundWithoutMatch() {
         final var object1 = new ObjectNode(null, Map.of(
-            "a", TextNode.valueOf("a"),
-            "b", TextNode.valueOf("b")
+            "a", StringNode.valueOf("a"),
+            "b", StringNode.valueOf("b")
         ));
         final var object2 = new ObjectNode(null, Map.of(
-            "a", TextNode.valueOf("c"),
-            "b", TextNode.valueOf("d")
+            "a", StringNode.valueOf("c"),
+            "b", StringNode.valueOf("d")
         ));
         final var parentMatcher = Mockito.mock(JsonMatcher.class);
         Mockito.when(parentMatcher.diff(any(), any(), any())).thenAnswer((args) -> nonMatchJsonDiff(args.getArgument(0)));
@@ -72,12 +72,12 @@ class LenientJsonObjectPartialMatcherTest {
     @Test
     void shouldMixMatchingAndNotFoundPropertiesOnSameResult() {
         final var object1 = new ObjectNode(null, Map.of(
-                "a", TextNode.valueOf("a"),
-                "b", TextNode.valueOf("b")
+                "a", StringNode.valueOf("a"),
+                "b", StringNode.valueOf("b")
         ));
         final var object2 = new ObjectNode(null, Map.of(
-                "a", TextNode.valueOf("a"),
-                "c", TextNode.valueOf("b")
+                "a", StringNode.valueOf("a"),
+                "c", StringNode.valueOf("b")
         ));
         final var parentMatcher = Mockito.mock(JsonMatcher.class);
         Mockito.when(parentMatcher.diff(any(), any(), any())).thenAnswer((args) -> fullMatchJsonDiff(args.getArgument(0)));
@@ -94,12 +94,12 @@ class LenientJsonObjectPartialMatcherTest {
     @Test
     void shouldReturnFullMatchingPropertyAllPropertiesAreFoundAndMatch() {
         final var object1 = new ObjectNode(null, Map.of(
-                "a", TextNode.valueOf("a"),
-                "b", TextNode.valueOf("b")
+                "a", StringNode.valueOf("a"),
+                "b", StringNode.valueOf("b")
         ));
         final var object2 = new ObjectNode(null, Map.of(
-                "a", TextNode.valueOf("a"),
-                "b", TextNode.valueOf("b")
+                "a", StringNode.valueOf("a"),
+                "b", StringNode.valueOf("b")
         ));
         final var parentMatcher = Mockito.mock(JsonMatcher.class);
         Mockito.when(parentMatcher.diff(any(), any(), any())).thenAnswer((args) -> fullMatchJsonDiff(args.getArgument(0)));
@@ -116,12 +116,12 @@ class LenientJsonObjectPartialMatcherTest {
     @Test
     void shouldReturnSimilarityIfOnlyOneProperty() {
         final var object1 = new ObjectNode(null, Map.of(
-                "a", TextNode.valueOf("a"),
-                "b", TextNode.valueOf("b"),
-                "c", TextNode.valueOf("b")
+                "a", StringNode.valueOf("a"),
+                "b", StringNode.valueOf("b"),
+                "c", StringNode.valueOf("b")
         ));
         final var object2 = new ObjectNode(null, Map.of(
-                "a", TextNode.valueOf("a")
+                "a", StringNode.valueOf("a")
         ));
         final var parentMatcher = Mockito.mock(JsonMatcher.class);
         Mockito.when(parentMatcher.diff(any(), any(), any())).thenAnswer((args) -> fullMatchJsonDiff(args.getArgument(0)));

--- a/src/test/java/com/deblock/jsondiff/matcher/LenientNumberPrimitivePartialMatcherTest.java
+++ b/src/test/java/com/deblock/jsondiff/matcher/LenientNumberPrimitivePartialMatcherTest.java
@@ -1,9 +1,9 @@
 package com.deblock.jsondiff.matcher;
 
 import com.deblock.jsondiff.diff.JsonDiff;
-import com.fasterxml.jackson.databind.node.DecimalNode;
-import com.fasterxml.jackson.databind.node.IntNode;
-import com.fasterxml.jackson.databind.node.TextNode;
+import tools.jackson.databind.node.DecimalNode;
+import tools.jackson.databind.node.IntNode;
+import tools.jackson.databind.node.StringNode;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
@@ -77,7 +77,7 @@ public class LenientNumberPrimitivePartialMatcherTest {
     @Test
     public void shouldCallTheDelegatedIfNodeHaveDifferentType() {
         final var value1 = IntNode.valueOf(100);
-        final var value2 = TextNode.valueOf("100");
+        final var value2 = StringNode.valueOf("100");
         final var jsonMatcher = Mockito.mock(JsonMatcher.class);
         final var delegated = Mockito.mock(PartialJsonMatcher.class);
         final var expectedJsonDiff = Mockito.mock(JsonDiff.class);

--- a/src/test/java/com/deblock/jsondiff/matcher/StrictJsonArrayPartialMatcherTest.java
+++ b/src/test/java/com/deblock/jsondiff/matcher/StrictJsonArrayPartialMatcherTest.java
@@ -2,8 +2,8 @@ package com.deblock.jsondiff.matcher;
 
 import com.deblock.jsondiff.diff.JsonDiff;
 import com.deblock.jsondiff.viewer.JsonDiffViewer;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.TextNode;
+import tools.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.node.StringNode;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
@@ -17,8 +17,8 @@ class StrictJsonArrayPartialMatcherTest {
 
     @Test
     void shouldReturnFullMatchWhenAllItemsAreFound() {
-        final var array1 = new ArrayNode(null, List.of(TextNode.valueOf("a"), TextNode.valueOf("b")));
-        final var array2 = new ArrayNode(null, List.of(TextNode.valueOf("a"), TextNode.valueOf("b")));
+        final var array1 = new ArrayNode(null, List.of(StringNode.valueOf("a"), StringNode.valueOf("b")));
+        final var array2 = new ArrayNode(null, List.of(StringNode.valueOf("a"), StringNode.valueOf("b")));
         final var jsonMatcher = Mockito.mock(JsonMatcher.class);
         Mockito.when(jsonMatcher.diff(any(), any(), any())).thenAnswer(this::matchByEquality);
 
@@ -49,8 +49,8 @@ class StrictJsonArrayPartialMatcherTest {
 
     @Test
     void shouldReturnNoMatchWhenItemsAreNonOrdered() {
-        final var array1 = new ArrayNode(null, List.of(TextNode.valueOf("a"), TextNode.valueOf("b")));
-        final var array2 = new ArrayNode(null, List.of(TextNode.valueOf("b"), TextNode.valueOf("a")));
+        final var array1 = new ArrayNode(null, List.of(StringNode.valueOf("a"), StringNode.valueOf("b")));
+        final var array2 = new ArrayNode(null, List.of(StringNode.valueOf("b"), StringNode.valueOf("a")));
         final var jsonMatcher = Mockito.mock(JsonMatcher.class);
         Mockito.when(jsonMatcher.diff(any(), any(), any())).thenAnswer(this::matchByEquality);
 
@@ -66,8 +66,8 @@ class StrictJsonArrayPartialMatcherTest {
 
     @Test
     void shouldReturnNoMatchWhenSameNumberItemWithNoMatch() {
-        final var array1 = new ArrayNode(null, List.of(TextNode.valueOf("a"), TextNode.valueOf("b")));
-        final var array2 = new ArrayNode(null, List.of(TextNode.valueOf("c"), TextNode.valueOf("d")));
+        final var array1 = new ArrayNode(null, List.of(StringNode.valueOf("a"), StringNode.valueOf("b")));
+        final var array2 = new ArrayNode(null, List.of(StringNode.valueOf("c"), StringNode.valueOf("d")));
         final var jsonMatcher = Mockito.mock(JsonMatcher.class);
         Mockito.when(jsonMatcher.diff(any(), any(), any())).thenAnswer(this::matchByEquality);
 
@@ -83,8 +83,8 @@ class StrictJsonArrayPartialMatcherTest {
 
     @Test
     void shouldReturnPartialMatchWhenMissingItem() {
-        final var array1 = new ArrayNode(null, List.of(TextNode.valueOf("a"), TextNode.valueOf("b")));
-        final var array2 = new ArrayNode(null, List.of(TextNode.valueOf("a")));
+        final var array1 = new ArrayNode(null, List.of(StringNode.valueOf("a"), StringNode.valueOf("b")));
+        final var array2 = new ArrayNode(null, List.of(StringNode.valueOf("a")));
         final var jsonMatcher = Mockito.mock(JsonMatcher.class);
         Mockito.when(jsonMatcher.diff(any(), any(), any())).thenAnswer(this::matchByEquality);
 
@@ -100,8 +100,8 @@ class StrictJsonArrayPartialMatcherTest {
 
     @Test
     void shouldReturnPartialMatchWhenExtraItems() {
-        final var array1 = new ArrayNode(null, List.of(TextNode.valueOf("a"), TextNode.valueOf("c")));
-        final var array2 = new ArrayNode(null, List.of(TextNode.valueOf("a"), TextNode.valueOf("b"), TextNode.valueOf("c")));
+        final var array1 = new ArrayNode(null, List.of(StringNode.valueOf("a"), StringNode.valueOf("c")));
+        final var array2 = new ArrayNode(null, List.of(StringNode.valueOf("a"), StringNode.valueOf("b"), StringNode.valueOf("c")));
         final var jsonMatcher = Mockito.mock(JsonMatcher.class);
         Mockito.when(jsonMatcher.diff(any(), any(), any())).thenAnswer(this::matchByEquality);
 

--- a/src/test/java/com/deblock/jsondiff/matcher/StrictJsonObjectPartialMatcherTest.java
+++ b/src/test/java/com/deblock/jsondiff/matcher/StrictJsonObjectPartialMatcherTest.java
@@ -2,10 +2,10 @@ package com.deblock.jsondiff.matcher;
 
 import com.deblock.jsondiff.diff.JsonDiff;
 import com.deblock.jsondiff.viewer.JsonDiffViewer;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.fasterxml.jackson.databind.node.TextNode;
+import tools.jackson.databind.node.ObjectNode;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
+import tools.jackson.databind.node.StringNode;
 
 import java.util.Map;
 
@@ -29,8 +29,8 @@ class StrictJsonObjectPartialMatcherTest {
     @Test
     void shouldReturnNonMachIfAllPropertiesAreNotFound() {
         final var object1 = new ObjectNode(null, Map.of(
-            "a", TextNode.valueOf("a"),
-            "b", TextNode.valueOf("b")
+            "a", StringNode.valueOf("a"),
+            "b", StringNode.valueOf("b")
         ));
         final var object2 = new ObjectNode(null);
 
@@ -47,12 +47,12 @@ class StrictJsonObjectPartialMatcherTest {
     @Test
     void shouldReturnNonMatchingPropertyIfAllPropertiesAreFoundWithoutMatch() {
         final var object1 = new ObjectNode(null, Map.of(
-            "a", TextNode.valueOf("a"),
-            "b", TextNode.valueOf("b")
+            "a", StringNode.valueOf("a"),
+            "b", StringNode.valueOf("b")
         ));
         final var object2 = new ObjectNode(null, Map.of(
-            "a", TextNode.valueOf("c"),
-            "b", TextNode.valueOf("d")
+            "a", StringNode.valueOf("c"),
+            "b", StringNode.valueOf("d")
         ));
         final var parentMatcher = Mockito.mock(JsonMatcher.class);
         Mockito.when(parentMatcher.diff(any(), any(), any())).thenAnswer((args) -> nonMatchJsonDiff(args.getArgument(0)));
@@ -69,12 +69,12 @@ class StrictJsonObjectPartialMatcherTest {
     @Test
     void shouldMixMatchingAndNotFoundPropertiesOnSameResult() {
         final var object1 = new ObjectNode(null, Map.of(
-                "a", TextNode.valueOf("a"),
-                "b", TextNode.valueOf("b")
+                "a", StringNode.valueOf("a"),
+                "b", StringNode.valueOf("b")
         ));
         final var object2 = new ObjectNode(null, Map.of(
-                "a", TextNode.valueOf("a"),
-                "c", TextNode.valueOf("b")
+                "a", StringNode.valueOf("a"),
+                "c", StringNode.valueOf("b")
         ));
         final var parentMatcher = Mockito.mock(JsonMatcher.class);
         Mockito.when(parentMatcher.diff(any(), any(), any())).thenAnswer((args) -> fullMatchJsonDiff(args.getArgument(0)));
@@ -92,12 +92,12 @@ class StrictJsonObjectPartialMatcherTest {
     @Test
     void shouldReturnFullMatchingPropertyAllPropertiesAreFoundAndMatch() {
         final var object1 = new ObjectNode(null, Map.of(
-                "a", TextNode.valueOf("a"),
-                "b", TextNode.valueOf("b")
+                "a", StringNode.valueOf("a"),
+                "b", StringNode.valueOf("b")
         ));
         final var object2 = new ObjectNode(null, Map.of(
-                "a", TextNode.valueOf("a"),
-                "b", TextNode.valueOf("b")
+                "a", StringNode.valueOf("a"),
+                "b", StringNode.valueOf("b")
         ));
         final var parentMatcher = Mockito.mock(JsonMatcher.class);
         Mockito.when(parentMatcher.diff(any(), any(), any())).thenAnswer((args) -> fullMatchJsonDiff(args.getArgument(0)));

--- a/src/test/java/com/deblock/jsondiff/matcher/StrictPrimitivePartialMatcherTest.java
+++ b/src/test/java/com/deblock/jsondiff/matcher/StrictPrimitivePartialMatcherTest.java
@@ -1,9 +1,9 @@
 package com.deblock.jsondiff.matcher;
 
-import com.fasterxml.jackson.databind.node.BooleanNode;
-import com.fasterxml.jackson.databind.node.DecimalNode;
-import com.fasterxml.jackson.databind.node.IntNode;
-import com.fasterxml.jackson.databind.node.TextNode;
+import tools.jackson.databind.node.BooleanNode;
+import tools.jackson.databind.node.DecimalNode;
+import tools.jackson.databind.node.IntNode;
+import tools.jackson.databind.node.StringNode;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
@@ -16,8 +16,8 @@ public class StrictPrimitivePartialMatcherTest {
 
     @Test
     public void shouldReturnAFullMatchIfNodeAreEqualsString() {
-        final var string1 = TextNode.valueOf("a");
-        final var string2 = TextNode.valueOf("a");
+        final var string1 = StringNode.valueOf("a");
+        final var string2 = StringNode.valueOf("a");
 
         final var jsonDiff = new StrictPrimitivePartialMatcher().jsonDiff(expectedPath, string1, string2, Mockito.mock(JsonMatcher.class));
 
@@ -30,8 +30,8 @@ public class StrictPrimitivePartialMatcherTest {
 
     @Test
     public void shouldReturnANoMatchIfNodeAreNotEqualsString() {
-        final var string1 = TextNode.valueOf("a");
-        final var string2 = TextNode.valueOf("c");
+        final var string1 = StringNode.valueOf("a");
+        final var string2 = StringNode.valueOf("c");
 
         final var jsonDiff = new StrictPrimitivePartialMatcher().jsonDiff(expectedPath, string1, string2, Mockito.mock(JsonMatcher.class));
 
@@ -101,7 +101,7 @@ public class StrictPrimitivePartialMatcherTest {
     @Test
     public void shouldReturnANonMatchIfNodeHaveDifferentType() {
         final var value1 = IntNode.valueOf(100);
-        final var value2 = TextNode.valueOf("100");
+        final var value2 = StringNode.valueOf("100");
 
         final var jsonDiff = new StrictPrimitivePartialMatcher().jsonDiff(expectedPath, value1, value2, Mockito.mock(JsonMatcher.class));
 

--- a/src/test/java/com/deblock/jsondiff/viewer/OnlyErrorDiffViewerTest.java
+++ b/src/test/java/com/deblock/jsondiff/viewer/OnlyErrorDiffViewerTest.java
@@ -4,7 +4,7 @@ import com.deblock.jsondiff.diff.JsonObjectDiff;
 import com.deblock.jsondiff.diff.MatchedPrimaryDiff;
 import com.deblock.jsondiff.diff.UnMatchedPrimaryDiff;
 import com.deblock.jsondiff.matcher.Path;
-import com.fasterxml.jackson.databind.node.TextNode;
+import tools.jackson.databind.node.StringNode;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -17,13 +17,13 @@ public class OnlyErrorDiffViewerTest {
         final var viewer = new OnlyErrorDiffViewer();
         final var objectPath = path.add(Path.PathItem.of("b"));
         final var jsonObjectDiff = new JsonObjectDiff(objectPath);
-        jsonObjectDiff.addNotFoundProperty("c", TextNode.valueOf("a"));
+        jsonObjectDiff.addNotFoundProperty("c", StringNode.valueOf("a"));
 
-        viewer.matchingProperty(path.add(Path.PathItem.of("e")), new MatchedPrimaryDiff(path.add(Path.PathItem.of("e")), TextNode.valueOf("z")));
-        viewer.primaryMatching(path.add(Path.PathItem.of("d")), TextNode.valueOf("c"));
+        viewer.matchingProperty(path.add(Path.PathItem.of("e")), new MatchedPrimaryDiff(path.add(Path.PathItem.of("e")), StringNode.valueOf("z")));
+        viewer.primaryMatching(path.add(Path.PathItem.of("d")), StringNode.valueOf("c"));
         viewer.nonMatchingProperty(null, jsonObjectDiff);
-        viewer.primaryNonMatching(path.add(Path.PathItem.of("c")), TextNode.valueOf("a"), TextNode.valueOf("b"));
-        viewer.extraProperty(path.add(Path.PathItem.of("d")), TextNode.valueOf("d"));
+        viewer.primaryNonMatching(path.add(Path.PathItem.of("c")), StringNode.valueOf("a"), StringNode.valueOf("b"));
+        viewer.extraProperty(path.add(Path.PathItem.of("d")), StringNode.valueOf("d"));
 
         final var expected = "The property \"$.a.b.c\" in the expected json is not found\n" +
                 "The property \"$.a.c\" didn't match. Expected \"a\", Received: \"b\"\n" +
@@ -34,7 +34,7 @@ public class OnlyErrorDiffViewerTest {
 
     @Test
     public void canBuildAnOnlyErrorDiffViewerFromJsonDiff() {
-        final var jsonDiff = new UnMatchedPrimaryDiff(path, TextNode.valueOf("a"), TextNode.valueOf("b"));
+        final var jsonDiff = new UnMatchedPrimaryDiff(path, StringNode.valueOf("a"), StringNode.valueOf("b"));
 
         final var result = OnlyErrorDiffViewer.from(jsonDiff);
 


### PR DESCRIPTION
## Summary

- Migrate from Jackson 2.15.2 to Jackson 3.0.3 (new `tools.jackson` package)
- Upgrade Java target from 11 to 21
- Update test dependencies: JUnit 5.10.2, Mockito 5.21.0
- Add CLAUDE.md for AI-assisted development

## Breaking Changes

- **Java 21 required** - This library now requires Java 21 or higher
- **Jackson 3.x** - The new Jackson version uses a different package (`tools.jackson` instead of `com.fasterxml.jackson`)

## Test plan

- [x] All existing tests pass
- [ ] Verify compatibility with downstream projects

🤖 Generated with [Claude Code](https://claude.com/claude-code)