### PR TITLE
feat: migrate to JReleaser for Maven Central publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,40 +1,58 @@
-name: Publish to OSS Sonatype
+name: Publish to Maven Central
 
 on:
   release:
     types: [ created ]
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: 'Run in dry-run mode (no actual publish)'
+        required: true
+        default: true
+        type: boolean
 
 jobs:
   publish:
-
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      packages: write
+      contents: write
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
       - name: Set up JDK 21
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '21'
           distribution: 'temurin'
-          server-id: github
-          settings-path: ${{ github.workspace }}
+
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/actions/setup-gradle@v4
 
       - name: Build with Gradle
-        uses: gradle/gradle-build-action@67421db6bd0bf253fb4bd25b31ebb98943c375e1
-        with:
-          arguments: build
+        run: ./gradlew build
 
-      - name: Publish to maven central
-        uses: gradle/gradle-build-action@67421db6bd0bf253fb4bd25b31ebb98943c375e1
+      - name: Publish to staging
+        run: ./gradlew publishAllPublicationsToStagingRepository
+
+      - name: Deploy with JReleaser
+        uses: jreleaser/release-action@v2
         with:
-          arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+          arguments: deploy ${{ inputs.dry-run && '--dry-run' || '' }}
         env:
-          ORG_GRADLE_PROJECT_sonatypeUsername: ${{ secrets.SONATYPE_USERNAME }}
-          ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.SONATYPE_PASSWORD }}
-          ORG_GRADLE_PROJECT_signingKey: ${{ secrets.GPG_PRIVATE_KEY  }}
-          ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.SIGNING_PASSWORD }}
+          JRELEASER_MAVENCENTRAL_SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+          JRELEASER_MAVENCENTRAL_SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+          JRELEASER_GPG_PASSPHRASE: ${{ secrets.SIGNING_PASSWORD }}
+          JRELEASER_GPG_SECRET_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+          JRELEASER_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload JReleaser logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: jreleaser-logs
+          path: |
+            out/jreleaser/trace.log
+            out/jreleaser/output.properties

--- a/build.gradle
+++ b/build.gradle
@@ -5,11 +5,9 @@
  */
 
 plugins {
-    id 'io.github.gradle-nexus.publish-plugin' version '1.3.0'
     id 'me.qoomon.git-versioning' version '6.4.1'
     id 'java'
     id 'maven-publish'
-    id 'signing'
 }
 
 repositories {
@@ -59,14 +57,6 @@ test {
     useJUnitPlatform()
 }
 
-nexusPublishing {
-    repositories {
-        sonatype {
-            nexusUrl.set(uri('https://s01.oss.sonatype.org/service/local/'))
-            snapshotRepositoryUrl.set(uri('https://s01.oss.sonatype.org/content/repositories/snapshots/'))
-        }
-    }
-}
 
 publishing {
     publications {
@@ -97,21 +87,19 @@ publishing {
                 }
 
                 scm {
-                    connection = 'https://github.com/deblockt/json-diff.git'
-                    developerConnection = 'https://github.com/deblockt/json-diff.git'
+                    connection = 'scm:git:https://github.com/deblockt/json-diff.git'
+                    developerConnection = 'scm:git:ssh://github.com/deblockt/json-diff.git'
                     url = 'https://github.com/deblockt/json-diff'
                 }
             }
         }
     }
 
-    signing {
-        def signingKey = findProperty("signingKey")
-        def signingPassword = findProperty("signingPassword")
-        if (signingKey !== null && signingPassword != null) {
-            useInMemoryPgpKeys(signingKey, signingPassword)
+    repositories {
+        maven {
+            name = 'staging'
+            url = layout.buildDirectory.dir('staging-deploy')
         }
-
-        sign publishing.publications.mavenJava
     }
 }
+

--- a/jreleaser.yml
+++ b/jreleaser.yml
@@ -1,0 +1,21 @@
+project:
+  name: json-diff
+  description: A customizable lib to perform a json-diff
+  links:
+    homepage: https://github.com/deblockt/json-diff
+  authors:
+    - Thomas Deblock
+  license: Apache-2.0
+  inceptionYear: "2022"
+
+signing:
+  active: ALWAYS
+  armored: true
+
+deploy:
+  maven:
+    mavenCentral:
+      sonatype:
+        active: ALWAYS
+        url: https://central.sonatype.com/api/v1/publisher
+        stagingRepository: build/staging-deploy


### PR DESCRIPTION
## Summary
- Replace `nexus-publish-plugin` with JReleaser CLI for publishing to Maven Central
- Use the new Central Portal API (`https://central.sonatype.com`)
- Add `workflow_dispatch` trigger with dry-run option for testing

## Changes
- **build.gradle**: Remove nexus-publish-plugin and signing plugin, add staging repository
- **jreleaser.yml**: New config for Central Portal deployment
- **publish.yml**: Use `jreleaser/release-action@v2` instead of Gradle nexus tasks

## Test plan
- [ ] Run workflow manually with dry-run enabled to verify configuration
- [ ] Check JReleaser logs artifact for any errors
- [ ] Create a test release to verify end-to-end publishing

## Required secrets
Same as before:
- `SONATYPE_USERNAME` - Central Portal username
- `SONATYPE_PASSWORD` - Central Portal token
- `GPG_PRIVATE_KEY` - GPG signing key
- `SIGNING_PASSWORD` - GPG passphrase

🤖 Generated with [Claude Code](https://claude.com/claude-code)