### PR TITLE
ci: add release workflow with automatic semantic versioning

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,17 +1,24 @@
-name: Publish to Maven Central
+name: Release
 
 on:
-  release:
-    types: [ created ]
+  workflow_dispatch:
+    inputs:
+      force-major:
+        description: 'Force major version bump'
+        required: false
+        type: boolean
+        default: false
 
 jobs:
-  publish:
+  release:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up JDK 21
         uses: actions/setup-java@v4
@@ -21,6 +28,14 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
+
+      - name: Calculate and create tag
+        id: version
+        uses: mathieudutour/github-tag-action@v6.2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          default_bump: ${{ inputs.force-major && 'major' || 'patch' }}
+          release_branches: master
 
       - name: Build with Gradle
         run: ./gradlew build
@@ -38,6 +53,14 @@ jobs:
           JRELEASER_GPG_PASSPHRASE: ${{ secrets.SIGNING_PASSWORD }}
           JRELEASER_GPG_SECRET_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
           JRELEASER_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "${{ steps.version.outputs.new_tag }}" \
+            --title "${{ steps.version.outputs.new_tag }}" \
+            --generate-notes
 
       - name: Upload JReleaser logs
         if: always()


### PR DESCRIPTION
## Summary
Nouveau workflow de release avec versioning sémantique automatique basé sur les conventional commits.

## Changes
- Supprime `publish.yml` (déclenché sur release manuelle)
- Ajoute `release.yml` (workflow manuel avec version auto)

## Fonctionnement

| Commit | Version bump |
|--------|--------------|
| `fix:`, `docs:`, `refactor:`, etc. | **patch** (2.0.0 → 2.0.1) |
| `feat:` | **minor** (2.0.0 → 2.1.0) |
| `feat!:` ou `BREAKING CHANGE:` | **major** (2.0.0 → 3.0.0) |

Option "Force major" disponible pour forcer une major.

## Utilisation
1. Actions → Release → Run workflow
2. (Optionnel) Cocher "Force major version bump"
3. Le workflow analyse les commits et release automatiquement

🤖 Generated with [Claude Code](https://claude.com/claude-code)